### PR TITLE
Fixed futures ticker handling and socket option copying

### DIFF
--- a/BitMart.Net.UnitTests/SocketSubscriptionTests.cs
+++ b/BitMart.Net.UnitTests/SocketSubscriptionTests.cs
@@ -75,6 +75,20 @@ namespace BitMart.Net.UnitTests
         }
 
         [Test]
+        public async Task ValidateFuturesTickerAlternateIdentifierSubscription()
+        {
+            var logger = new LoggerFactory();
+            logger.AddProvider(new TraceLoggerProvider());
+
+            var client = new BitMartSocketClient(Options.Create(new BitMartSocketOptions
+            {
+                OutputOriginalData = true
+            }), logger);
+            var tester = new SocketSubscriptionValidator<BitMartSocketClient>(client, "Subscriptions/Futures", "wss://openapi-ws.bitmart.com", "data");
+            await tester.ValidateAsync<BitMartFuturesTickerUpdate>((client, handler) => client.UsdFuturesApi.SubscribeToTickerUpdatesAsync("AXONUSDT", handler), "TickerAlternateIdentifier");
+        }
+
+        [Test]
         public async Task ValidateFuturesSubscriptions()
         {
             var logger = new LoggerFactory();

--- a/BitMart.Net.UnitTests/Subscriptions/Futures/Ticker.txt
+++ b/BitMart.Net.UnitTests/Subscriptions/Futures/Ticker.txt
@@ -6,7 +6,8 @@
     "data":{
           "symbol":"BTCUSDT",
           "volume_24":"117387.58",
-          "fair_price":"146.24",
+          "mark_price":"146.24",
+          "index_price":"146.20",
           "last_price":"146.24",
           "range":"147.17",
           "ask_price": "147.11",

--- a/BitMart.Net.UnitTests/Subscriptions/Futures/TickerAlternateIdentifier.txt
+++ b/BitMart.Net.UnitTests/Subscriptions/Futures/TickerAlternateIdentifier.txt
@@ -1,0 +1,18 @@
+> {"action": "subscribe", "args": ["futures/ticker:AXONUSDT"]}
+< {"action":"subscribe","group":"futures/ticker:AXONUSDT","success":true,"request":{"action":"subscribe","args":["futures/ticker:AXONUSDT"]}}
+=
+{
+    "group":"futures/ticker:AXONUSDT@100ms",
+    "data":{
+          "symbol":"AXONUSDT",
+          "volume_24":"246128",
+          "mark_price":"567.02",
+          "index_price":"566.445020726126944",
+          "last_price":"566.92",
+          "range":"-0.0117663465058309",
+          "ask_price":"568.75",
+          "ask_vol":"1",
+          "bid_price":"565.22",
+          "bid_vol":"1"
+        }
+}

--- a/BitMart.Net/Clients/MessageHandlers/BitMartSocketUsdFuturesMessageConverter.cs
+++ b/BitMart.Net/Clients/MessageHandlers/BitMartSocketUsdFuturesMessageConverter.cs
@@ -38,8 +38,17 @@ namespace BitMart.Net.Clients.UsdFuturesApi
                 Fields = [
                     new PropertyFieldReference("group").WithNotEqualConstraint("System"),
                 ],
-                TypeIdentifierCallback = x => $"{x.FieldValue("group")}"
+                TypeIdentifierCallback = x => NormalizeEventIdentifier(x.FieldValue("group")!)
             },
         ];
+
+        private static string NormalizeEventIdentifier(string identifier)
+        {
+            var separatorIndex = identifier.LastIndexOf('@');
+            if (separatorIndex < 0 || !identifier.EndsWith("ms", System.StringComparison.Ordinal))
+                return identifier;
+
+            return identifier.Substring(0, separatorIndex);
+        }
     }
 }

--- a/BitMart.Net/Objects/Models/BitMartFuturesTickerUpdate.cs
+++ b/BitMart.Net/Objects/Models/BitMartFuturesTickerUpdate.cs
@@ -22,10 +22,16 @@ namespace BitMart.Net.Objects.Models
         public decimal Volume24h { get; set; }
 
         /// <summary>
-        /// ["<c>fair_price</c>"] Fair price
+        /// ["<c>mark_price</c>"] Mark price
         /// </summary>
-        [JsonPropertyName("fair_price")]
-        public decimal FairPrice { get; set; }
+        [JsonPropertyName("mark_price")]
+        public decimal MarkPrice { get; set; }
+
+        /// <summary>
+        /// ["<c>index_price</c>"] Index price
+        /// </summary>
+        [JsonPropertyName("index_price")]
+        public decimal IndexPrice { get; set; }
 
         /// <summary>
         /// ["<c>last_price</c>"] Last trade price

--- a/BitMart.Net/Objects/Options/BitMartSocketOptions.cs
+++ b/BitMart.Net/Objects/Options/BitMartSocketOptions.cs
@@ -40,7 +40,7 @@ namespace BitMart.Net.Objects.Options
         {
             targetOptions = base.Set<BitMartSocketOptions>(targetOptions);
             targetOptions.UsdFuturesOptions = UsdFuturesOptions.Set(targetOptions.UsdFuturesOptions);
-            targetOptions.SpotOptions = UsdFuturesOptions.Set(targetOptions.UsdFuturesOptions);
+            targetOptions.SpotOptions = SpotOptions.Set(targetOptions.SpotOptions);
             return targetOptions;
         }
     }


### PR DESCRIPTION
- Updated the futures ticker model because BitMart replaced `fair_price` with `mark_price` and added `index_price`.
- Normalized trailing `@...ms` identifiers because BitMart sometimes adds them to data responses despite acknowledging an unsuffixed subscription topic.
- Fixed `BitMartSocketOptions.Set` because it incorrectly copied USD futures options into the spot options.
- Added regression fixtures covering the current ticker fields and alternate response identifier.