### PR TITLE
Shared asset types

### DIFF
--- a/BitMart.Net/BitMart.Net.csproj
+++ b/BitMart.Net/BitMart.Net.csproj
@@ -53,12 +53,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/BitMart.Net/BitMart.Net.csproj
+++ b/BitMart.Net/BitMart.Net.csproj
@@ -53,10 +53,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/BitMart.Net/Clients/SpotApi/BitMartRestClientSpotApiShared.cs
+++ b/BitMart.Net/Clients/SpotApi/BitMartRestClientSpotApiShared.cs
@@ -92,7 +92,7 @@ namespace BitMart.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
 
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/BitMart.Net/Clients/SpotApi/BitMartRestClientSpotApiShared.cs
+++ b/BitMart.Net/Clients/SpotApi/BitMartRestClientSpotApiShared.cs
@@ -1,14 +1,15 @@
-using BitMart.Net.Interfaces.Clients.SpotApi;
 using BitMart.Net.Enums;
+using BitMart.Net.Interfaces.Clients.SpotApi;
+using BitMart.Net.Objects.Models;
+using CryptoExchange.Net;
 using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using BitMart.Net.Objects.Models;
-using CryptoExchange.Net;
-using CryptoExchange.Net.Objects.Errors;
 
 namespace BitMart.Net.Clients.SpotApi
 {
@@ -91,6 +92,7 @@ namespace BitMart.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
 
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -103,17 +105,50 @@ namespace BitMart.Net.Clients.SpotApi
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var response = HttpResult.Ok(result, result.Data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.TradeStatus == SymbolStatus.Trading)
+            var data = result.Data
+                .Select(x => ParseSymbol(x)!)
+                .Where(x => x != null)
+                .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
+        }
+
+        private SharedSpotSymbol ParseSymbol(BitMartSymbol s)
+        {
+            var result = new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.TradeStatus == SymbolStatus.Trading)
             {
                 MinTradeQuantity = s.BaseMinQuantity,
                 QuantityStep = s.BaseMinQuantity,
                 PriceDecimals = s.PriceMaxPrecision,
-                MinNotionalValue = s.MinBuyQuantity == null && s.MinSellQuantity == null ? null : Math.Min(s.MinBuyQuantity ?? decimal.MaxValue, s.MinSellQuantity ?? decimal.MaxValue)
-            }).ToArray());
+                MinNotionalValue = s.MinBuyQuantity == null && s.MinSellQuantity == null ? null : Math.Min(s.MinBuyQuantity ?? decimal.MaxValue, s.MinSellQuantity ?? decimal.MaxValue),
+                QuoteAssetType = SharedAssetType.Crypto,
+                DisplayName = s.Symbol
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
-            return response;
+            if (LibraryHelpers.IsStableCoin(s.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+                result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
+
+            if (LibraryHelpers.IsStableCoin(s.QuoteAsset))
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+                result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
+
+            return result;
         }
+
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))

--- a/BitMart.Net/Clients/SpotApi/BitMartRestClientSpotApiShared.cs
+++ b/BitMart.Net/Clients/SpotApi/BitMartRestClientSpotApiShared.cs
@@ -138,12 +138,12 @@ namespace BitMart.Net.Clients.SpotApi
 
             if (LibraryHelpers.IsStableCoin(s.QuoteAsset))
             {
-                result.BaseAssetType = SharedAssetType.Crypto;
-                result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+                result.QuoteAssetType = SharedAssetType.Crypto;
+                result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
             }
             else
             {
-                result.BaseAssetType = SharedAssetType.Crypto;
+                result.QuoteAssetType = SharedAssetType.Crypto;
             }
 
             return result;

--- a/BitMart.Net/Clients/UsdFuturesApi/BitMartRestClientUsdFuturesApiShared.cs
+++ b/BitMart.Net/Clients/UsdFuturesApi/BitMartRestClientUsdFuturesApiShared.cs
@@ -161,7 +161,7 @@ namespace BitMart.Net.Clients.UsdFuturesApi
         #endregion
 
         #region Futures Symbol client
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/BitMart.Net/Clients/UsdFuturesApi/BitMartRestClientUsdFuturesApiShared.cs
+++ b/BitMart.Net/Clients/UsdFuturesApi/BitMartRestClientUsdFuturesApiShared.cs
@@ -223,7 +223,7 @@ namespace BitMart.Net.Clients.UsdFuturesApi
                     || s.TradfiInfo.MarketGroup == TradFiGroup.HkStock)
                 {
                     result.BaseAssetType = SharedAssetType.TradFi;
-                    result.BaseAssetSubType = SharedAssetSubType.Stock;
+                    result.BaseAssetSubType = SharedAssetSubType.Equity;
                 }
                 else if (s.TradfiInfo.MarketGroup == TradFiGroup.AuIndex
                     || s.TradfiInfo.MarketGroup == TradFiGroup.DeIndex
@@ -234,7 +234,7 @@ namespace BitMart.Net.Clients.UsdFuturesApi
                     || s.TradfiInfo.MarketGroup == TradFiGroup.UkIndex)
                 {
                     result.BaseAssetType = SharedAssetType.TradFi;
-                    result.BaseAssetSubType = SharedAssetSubType.Index;
+                    result.BaseAssetSubType = SharedAssetSubType.Equity;
                 }
                 else if (s.TradfiInfo.MarketGroup == TradFiGroup.MetalLme
                     || s.TradfiInfo.MarketGroup == TradFiGroup.CommodityCme

--- a/BitMart.Net/Clients/UsdFuturesApi/BitMartRestClientUsdFuturesApiShared.cs
+++ b/BitMart.Net/Clients/UsdFuturesApi/BitMartRestClientUsdFuturesApiShared.cs
@@ -24,9 +24,6 @@ namespace BitMart.Net.Clients.UsdFuturesApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BitMartExchange.Metadata, this);
 
-        private static HashSet<string> _knownMetals = ["PAXG", "XAUT", "XAU", "XAG", "XPD", "XPT", "XNI", "XCU", "XAL", "Copper", "SLVON"];
-        private static HashSet<string> _knownCommodities = ["NGAS", "BZ", "CL"];
-
         #region Balance client
         GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Futures);
 
@@ -209,7 +206,7 @@ namespace BitMart.Net.Clients.UsdFuturesApi
 
             if (s.TradfiInfo == null)
             {
-                if (_knownMetals.Contains(s.BaseAsset) || _knownCommodities.Contains(s.BaseAsset))
+                if (LibraryHelpers.IsCommodity(result.BaseAsset, "SLVON"))
                 {
                     // Some symbols like PAXGUSDT or NGASUSDT aren't considered Tradfi by the API
                     result.BaseAssetType = SharedAssetType.TradFi;

--- a/BitMart.Net/Clients/UsdFuturesApi/BitMartRestClientUsdFuturesApiShared.cs
+++ b/BitMart.Net/Clients/UsdFuturesApi/BitMartRestClientUsdFuturesApiShared.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using CryptoExchange.Net;
 using BitMart.Net.Objects.Models;
 using CryptoExchange.Net.Objects.Errors;
+using Microsoft.Extensions.Logging;
 
 namespace BitMart.Net.Clients.UsdFuturesApi
 {
@@ -22,6 +23,9 @@ namespace BitMart.Net.Clients.UsdFuturesApi
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BitMartExchange.Metadata, this);
+
+        private static HashSet<string> _knownMetals = ["PAXG", "XAUT", "XAU", "XAG", "XPD", "XPT", "XNI", "XCU", "XAL", "Copper", "SLVON"];
+        private static HashSet<string> _knownCommodities = ["NGAS", "BZ", "CL"];
 
         #region Balance client
         GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Futures);
@@ -160,6 +164,7 @@ namespace BitMart.Net.Clients.UsdFuturesApi
         #endregion
 
         #region Futures Symbol client
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -168,15 +173,21 @@ namespace BitMart.Net.Clients.UsdFuturesApi
             if (validationError != null)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
-            var result = await ExchangeData.GetContractsAsync(ct: ct).ConfigureAwait(false);
-            if (!result.Success)
-                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
+            var contracts = await ExchangeData.GetContractsAsync(ct: ct).ConfigureAwait(false);
+            if (!contracts.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(contracts);
 
-            IEnumerable<BitMartContract> data = result.Data;
-            if (request.TradingMode != null)
-                data = data.Where(x => request.TradingMode == TradingMode.PerpetualLinear ? x.ProductType == ContractType.Perpetual : x.ProductType != ContractType.Perpetual);
-            var response = HttpResult.Ok(result, data.Select(s => 
-            new SharedFuturesSymbol(
+            var data = contracts.Data
+                .Select(x => ParseSymbol(x))
+                .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(contracts, SharedUtils.ApplySymbolFilter(data, request));
+        }
+
+        private SharedFuturesSymbol ParseSymbol(BitMartContract s)
+        {
+            var result = new SharedFuturesSymbol(
                 s.ProductType == ContractType.Perpetual ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear,
                 s.BaseAsset,
                 s.QuoteAsset,
@@ -190,12 +201,64 @@ namespace BitMart.Net.Clients.UsdFuturesApi
                 ContractSize = s.ContractQuantity,
                 MaxTradeQuantity = s.MaxQuantity,
                 MaxLongLeverage = s.MaxLeverage,
-                MaxShortLeverage = s.MaxLeverage
-            }).ToArray());
+                MaxShortLeverage = s.MaxLeverage,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin,
+                DisplayName = s.Symbol
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
-            return response;
+            if (s.TradfiInfo == null)
+            {
+                if (_knownMetals.Contains(s.BaseAsset) || _knownCommodities.Contains(s.BaseAsset))
+                {
+                    // Some symbols like PAXGUSDT or NGASUSDT aren't considered Tradfi by the API
+                    result.BaseAssetType = SharedAssetType.TradFi;
+                    result.BaseAssetSubType = SharedAssetSubType.Commodity;
+                }
+
+                result.BaseAssetType = SharedAssetType.Crypto;
+                if (LibraryHelpers.IsStableCoin(s.BaseAsset))
+                    result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else
+            {
+                if (s.TradfiInfo.MarketGroup == TradFiGroup.UsMarket
+                    || s.TradfiInfo.MarketGroup == TradFiGroup.HkStock)
+                {
+                    result.BaseAssetType = SharedAssetType.TradFi;
+                    result.BaseAssetSubType = SharedAssetSubType.Stock;
+                }
+                else if (s.TradfiInfo.MarketGroup == TradFiGroup.AuIndex
+                    || s.TradfiInfo.MarketGroup == TradFiGroup.DeIndex
+                    || s.TradfiInfo.MarketGroup == TradFiGroup.HkIndex
+                    || s.TradfiInfo.MarketGroup == TradFiGroup.JpIndex
+                    || s.TradfiInfo.MarketGroup == TradFiGroup.KrIndex
+                    || s.TradfiInfo.MarketGroup == TradFiGroup.TwIndex
+                    || s.TradfiInfo.MarketGroup == TradFiGroup.UkIndex)
+                {
+                    result.BaseAssetType = SharedAssetType.TradFi;
+                    result.BaseAssetSubType = SharedAssetSubType.Index;
+                }
+                else if (s.TradfiInfo.MarketGroup == TradFiGroup.MetalLme
+                    || s.TradfiInfo.MarketGroup == TradFiGroup.CommodityCme
+                    || s.TradfiInfo.MarketGroup == TradFiGroup.CommodityIce)
+                {
+                    result.BaseAssetType = SharedAssetType.TradFi;
+                    result.BaseAssetSubType = SharedAssetSubType.Commodity;
+                }
+                else if (s.TradfiInfo.MarketGroup == TradFiGroup.Forex)
+                {
+                    result.BaseAssetType = SharedAssetType.Fiat;
+                }
+                else if (s.TradfiInfo.MarketGroup == TradFiGroup.PreListing)
+                {
+                    result.BaseAssetType = SharedAssetType.TradFi;
+                }
+            }
+
+            return result;
         }
+
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))

--- a/BitMart.Net/Enums/SessionStatus.cs
+++ b/BitMart.Net/Enums/SessionStatus.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+using CryptoExchange.Net.Converters.SystemTextJson;
+using CryptoExchange.Net.Attributes;
+
+namespace BitMart.Net.Enums
+{
+    /// <summary>
+    /// Trade session status
+    /// </summary>
+    [JsonConverter(typeof(EnumConverter<SessionStatus>))]
+    public enum SessionStatus
+    {
+        /// <summary>
+        /// ["<c>1</c>"] Normal trading
+        /// </summary>
+        [Map("1")]
+        NormalTradingMode,
+        /// <summary>
+        /// ["<c>2</c>"] Low liquidity mode
+        /// </summary>
+        [Map("2")]
+        LowLiquidityMode
+    }
+}

--- a/BitMart.Net/Enums/TradFiGroup.cs
+++ b/BitMart.Net/Enums/TradFiGroup.cs
@@ -1,0 +1,84 @@
+using System.Text.Json.Serialization;
+using CryptoExchange.Net.Converters.SystemTextJson;
+using CryptoExchange.Net.Attributes;
+
+namespace BitMart.Net.Enums
+{
+    /// <summary>
+    /// TradFi group type
+    /// </summary>
+    [JsonConverter(typeof(EnumConverter<TradFiGroup>))]
+    public enum TradFiGroup
+    {
+        /// <summary>
+        /// ["<c>US_MARKET</c>"] US market
+        /// </summary>
+        [Map("US_MARKET")]
+        UsMarket,
+        /// <summary>
+        /// ["<c>FOREX</c>"] Forex
+        /// </summary>
+        [Map("FOREX")]
+        Forex,
+        /// <summary>
+        /// ["<c>HK_STOCK</c>"] HK stock
+        /// </summary>
+        [Map("HK_STOCK")]
+        HkStock,
+        /// <summary>
+        /// ["<c>INDEX_UK</c>"] UK Index
+        /// </summary>
+        [Map("INDEX_UK")]
+        UkIndex,
+        /// <summary>
+        /// ["<c>INDEX_JP</c>"] JP Index
+        /// </summary>
+        [Map("INDEX_JP")]
+        JpIndex,
+        /// <summary>
+        /// ["<c>INDEX_HK</c>"] HK Index
+        /// </summary>
+        [Map("INDEX_HK")]
+        HkIndex,
+        /// <summary>
+        /// ["<c>INDEX_AU</c>"] AU Index
+        /// </summary>
+        [Map("INDEX_AU")]
+        AuIndex,
+        /// <summary>
+        /// ["<c>INDEX_TW</c>"] TW Index
+        /// </summary>
+        [Map("INDEX_TW")]
+        TwIndex,
+        /// <summary>
+        /// ["<c>INDEX_DE</c>"] DE Index
+        /// </summary>
+        [Map("INDEX_DE")]
+        DeIndex,
+        /// <summary>
+        /// ["<c>INDEX_KR</c>"] KR Index
+        /// </summary>
+        [Map("INDEX_KR")]
+        KrIndex,
+        /// <summary>
+        /// ["<c>METAL_LME</c>"] London metal exchange
+        /// </summary>
+        [Map("METAL_LME")]
+        MetalLme,
+        /// <summary>
+        /// ["<c>COMMODITY_CME</c>"] Cme group commodities
+        /// </summary>
+        [Map("COMMODITY_CME")]
+        CommodityCme,
+        /// <summary>
+        /// ["<c>COMMODITY_ICE</c>"] ICE commodities
+        /// </summary>
+        [Map("COMMODITY_ICE")]
+        CommodityIce,
+        /// <summary>
+        /// ["<c>PRE_LIST</c>"] Pre-listing
+        /// </summary>
+        [Map("PRE_LIST")]
+        PreListing,
+    }
+}

--- a/BitMart.Net/Objects/Models/BitMartContract.cs
+++ b/BitMart.Net/Objects/Models/BitMartContract.cs
@@ -176,6 +176,43 @@ namespace BitMart.Net.Objects.Models
         /// </summary>
         [JsonPropertyName("funding_time")]
         public DateTime? FundingTime { get; set; }
+        /// <summary>
+        /// ["<c>tradfi_info</c>"] TradFi info
+        /// </summary>
+        [JsonPropertyName("tradfi_info")]
+        public BitMartContractTradFiInfo? TradfiInfo { get; set; }
+    }
+
+    /// <summary>
+    /// TradFi info
+    /// </summary>
+    public record BitMartContractTradFiInfo
+    {
+        /// <summary>
+        /// ["<c>market_group</c>"] market group
+        /// </summary>
+        [JsonPropertyName("market_group")]
+        public TradFiGroup MarketGroup { get; set; }
+        /// <summary>
+        /// ["<c>market_session_status</c>"] Trading session status
+        /// </summary>
+        [JsonPropertyName("market_session_status")]
+        public SessionStatus SessionStatus { get; set; }
+        /// <summary>
+        /// ["<c>next_session_switch_ts</c>"] Next session switch timestamp
+        /// </summary>
+        [JsonPropertyName("next_session_switch_ts")]
+        public DateTime? SessionSwitchTime { get; set; }
+        /// <summary>
+        /// ["<c>next_session_switch_status</c>"] Next session status
+        /// </summary>
+        [JsonPropertyName("next_session_switch_status")]
+        public SessionStatus? NextSessionStatus { get; set; }
+        /// <summary>
+        /// ["<c>reduce_only</c>"] Reduce only
+        /// </summary>
+        [JsonPropertyName("reduce_only")]
+        public bool ReduceOnly { get; set; }
     }
 
 


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models
Added TradfiInfo to BitMartContract model